### PR TITLE
Fix for `HTMLElement.shadowRoot is deprecated.`

### DIFF
--- a/lib/chrome-color-picker.coffee
+++ b/lib/chrome-color-picker.coffee
@@ -238,7 +238,8 @@ module.exports = CCP =
       # get the editor's view (htmlelement)
       @EditorView = atom.views.getView @Editor
       # get the shadow root of the editor
-      @EditorRoot = @EditorView.shadowRoot or @EditorView.querySelector '.editor-contents'
+      # @EditorRoot = @EditorView.shadowRoot or @EditorView.querySelector '.editor-contents'
+      @EditorRoot = @EditorView
       # get the last cursor (assuming multiple cursors)
       Cursor = @Editor.getLastCursor()
 

--- a/lib/modules/ui/FloatingPanel.coffee
+++ b/lib/modules/ui/FloatingPanel.coffee
@@ -30,7 +30,7 @@ class FloatingPanel extends helper
     # clean slate
     @component.classList.remove 'down'
     @triangle.removeAttribute 'style'
-    top = Cursor.top - Editor.getScrollTop() + Cursor.height + tabs.clientHeight + 10
+    top = Cursor.top - Editor.getScrollTop() + Cursor.height + tabs.clientHeight + 40
     # get the actual cursor's bounds and prefer the selection
     ActualCursor = EditorRoot.querySelector('.highlight.selection > .region')
     # if this is not found then the region must be present


### PR DESCRIPTION
Fixes #21, #15 and #19.